### PR TITLE
Adds support (rough) for multiple lint matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "url": "https://github.com/lirantal/swagger-lint-api.git"
   },
   "dependencies": {
-    "debug": "^4.1.0"
+    "debug": "^4.1.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",

--- a/src/utils/SchemaUtils.js
+++ b/src/utils/SchemaUtils.js
@@ -51,12 +51,21 @@ class SchemaUtils {
 
       const ret = validationSchema.keyValidator(value)
 
-      if (!ret) {
+      /* if object, allow for .message, .valid */
+      if(typeof ret === 'object' && !ret.valid && ret.message) {
+        results.push({
+          valid: false,
+          path: m,
+          message:ret.message
+        })
+      } else if (!ret) {
         results.push({
           valid: false,
           path: m
         })
       }
+
+
     })
 
     return results

--- a/src/utils/SchemaUtils.js
+++ b/src/utils/SchemaUtils.js
@@ -1,41 +1,8 @@
 'use strict'
 
-const debug = require('debug')('SchemaUtils')
 const _ = require('lodash')
 
 class SchemaUtils {
-  /*
-  static recursivelyFindKeyValueInObjects(validationSchema, inputSchema, path) {
-    if (inputSchema && typeof inputSchema === 'object') {
-      for (const [key, value] of Object.entries(inputSchema)) {
-        if (key === validationSchema.key) {
-          debug(`found a ${validationSchema.key} key`)
-
-          const ret = validationSchema.keyValidator(value)
-          if (ret) {
-            debug(`key ${validationSchema.key} is valid in path: ${path}`)
-          } else {
-            debug(`key ${validationSchema.key} is invalid in path: ${path}`)
-            return {
-              valid: false,
-              path: path.concat(key)
-            }
-          }
-        } else {
-          debug(`traversing deeper for key: ${validationSchema.key}`)
-          path.push(key)
-          const ret = SchemaUtils.recursivelyFindKeyValueInObjects(validationSchema, value, path)
-          if (ret) {
-            return ret
-          } else {
-            path.pop()
-          }
-        }
-      }
-    }
-  }
-  */
-
   static getPaths(obj, parentPath = [], paths = []) {
     if (typeof obj !== 'object') return paths
 
@@ -56,27 +23,6 @@ class SchemaUtils {
 
   static recursivelyFindKeyValueInObjects(validationSchema, inputSchema, path) {
     let results = []
-
-    /*
-    function getPaths(obj, parentPath = [], paths = []) {
-      if(typeof obj !== "object") return paths;
-
-      for(let prop in obj){
-          const currentPath = [...parentPath, prop];
-
-          paths.push([...currentPath]);
-
-          getPaths(obj[prop], currentPath, paths);
-      }
-
-      return paths;
-    }
-    */
-    /*
-    function findProps(obj, target) {
-      return getPaths(obj).filter(path => path.includes(target));
-    }
-    */
 
     const matches = this.findProps(inputSchema, 'description')
 

--- a/src/utils/SchemaUtils.js
+++ b/src/utils/SchemaUtils.js
@@ -6,19 +6,29 @@ class SchemaUtils {
   static getPaths(obj, parentPath = [], paths = []) {
     if (typeof obj !== 'object') return paths
 
-    for (let prop in obj) {
-      const currentPath = [...parentPath, prop]
+    if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        const currentPath = [...parentPath, `[${i}]`]
 
-      paths.push([...currentPath])
+        paths.push([...currentPath])
 
-      this.getPaths(obj[prop], currentPath, paths)
+        this.getPaths(obj[i], currentPath, paths)
+      }
+    } else {
+      for (let prop in obj) {
+        const currentPath = [...parentPath, prop]
+
+        paths.push([...currentPath])
+
+        this.getPaths(obj[prop], currentPath, paths)
+      }
     }
 
     return paths
   }
 
   static findProps(obj, target) {
-    return this.getPaths(obj).filter(path => path.includes(target))
+    return this.getPaths(obj).filter(paths => paths.slice(-1).includes(target))
   }
 
   static recursivelyFindKeyValueInObjects(validationSchema, inputSchema, path) {
@@ -30,7 +40,11 @@ class SchemaUtils {
       // first get a ref
       let path = ''
       m.forEach(i => {
-        path += "['" + i + "']"
+        if (i.charAt(0) === '[') {
+          path += i
+        } else {
+          path += "['" + i + "']"
+        }
       })
 
       let value = _.get(inputSchema, path)
@@ -40,7 +54,7 @@ class SchemaUtils {
       if (!ret) {
         results.push({
           valid: false,
-          path
+          path: m
         })
       }
     })


### PR DESCRIPTION

## Description

Modifies SchemaUtils such that more than the first failing match is returned. The idea is that, originally, you would just get a message saying "this swagger failed this test", and while that was true, it would be more helpful to see *all* the failures for a test so you can attempt to fix them at once.

I'd like to more here too. Right now it returns valid:false with each result, but the mere presence of the result now implies a failure, so that's a waste of data.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/swagger-lint-api/issues/3

## Motivation and Context

See above.

## How Has This Been Tested?

Not yet

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ]x I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] I added a picture of a cute animal cause it's fun

![image](https://user-images.githubusercontent.com/393660/62066824-e5166780-b1f7-11e9-889b-b1c9c56728c0.png)
