### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="https://www.npmjs.org/package/swagger-lint-api"><img src="https://badgen.net/npm/dt/swagger-lint-api" alt="downloads"/></a>
   <a href="https://travis-ci.org/lirantal/swagger-lint-api"><img src="https://badgen.net/travis/lirantal/swagger-lint-api" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/swagger-lint-api"><img src="https://badgen.net/codecov/c/github/lirantal/swagger-lint-api" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/swagger-lint-api"><img src="https://snyk.io/test/github/lirantal/swagger-lint-api/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Security Responsible Disclosure" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.